### PR TITLE
omit slack, fix text

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <div class="title-col">
       <h2 class="intro-offset">The Workshop Aims</h2>
       <p>
-        The community developing text analysis software tools (libraries and packages aimed at programmers) has grown a lot in recent years, some of it coordinated, some of it not. The text analysis eco-system has become richer but also more difficult to integrate.  This workshop is designed to bring the text package developers' community, to share experiences and knowledge, and hopefully foster cooperation.  To ensure a safe, enjoyable, and friendly experience for everyone who participates, we have a strict <a href="coc.html" title="Text workshop code of conduct">code of conduct</a>.
+        The community developing text analysis software tools (libraries and packages aimed at programmers) has grown a lot in recent years, some of it coordinated, some of it not. The text analysis eco-system has become richer but also more difficult to integrate.  This workshop is designed to bring together the text package developers' community, to share experiences and knowledge, and hopefully foster cooperation.  To ensure a safe, enjoyable, and friendly experience for everyone who participates, we have a strict <a href="coc.html" title="Text workshop code of conduct">code of conduct</a>.
         <br>
       </p>
 
@@ -166,14 +166,13 @@
   <div class="wide-title-col">
     <h2>Prepare</h2>
 
-    <p class="byline-italic">In the (months and) weeks leading up the event, participants can discuss ideas and projects by creating issues on the official textworkshop18 Github page. Start watching the repository for new discussions by clicking the button below.</p>
+    <p class="byline-italic">In the (months and) weeks leading up the event, participants can discuss ideas and projects by creating issues on the official textworkshop18 GitHub page. Start watching the repository for new discussions by clicking the button below.</p>
 
     <a class="github-button" href="https://github.com/ropensci/textworkshop18/issues" data-icon="octicon-issue-opened" data-style="mega" data-count-api="/repos/ropensci/textworkshop18#open_issues_count" data-count-aria-label="# issues on GitHub" aria-label="Issue ropensci/textworkshop18 on GitHub">Current Discussions</a>
 
     <a class="github-button" href="https://github.com/ropensci/textworkshop18/subscription" data-icon="octicon-eye" data-style="mega" data-count-href="/ropensci/textworkshop18/watchers" data-count-api="/repos/ropensci/textworkshop18#subscribers_count" data-count-aria-label="# watchers on GitHub" aria-label="Watch ropensci/textworkshop18 on GitHub">Start Watching</a>
 
 
-    <p class="byline-italic">Also join the <a href="https://ropensci.slack.com/messages/text-sig/"><code>#text-sig</code></a> channel on the ropensci Slack team</a>.
   </div>
 
 </section>
@@ -198,7 +197,7 @@
     <a name="schedule" class="section-jump"></a>
     <h2 class="intro-offset">Schedule</h2>
     <p>
-    We haven't fixed this year, but last year's schedule is available from the 2017 Conference's <a href="https://github.com/ropensci/textworkshop17/blob/master/preliminary_schedule.md#schedule">Github Page</a>.
+    We haven't fixed this year, but last year's schedule is available from the 2017 Conference's <a href="https://github.com/ropensci/textworkshop17/blob/master/preliminary_schedule.md#schedule">GitHub Page</a>.
     </p>
 </div>
 


### PR DESCRIPTION
- s/Github/GitHub
- deleted reference to Slack
- add word to: "...workshop is designed to bring *together* the text package developers' community..."
